### PR TITLE
Rename uniform_tt to flat_tt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorTrains"
 uuid = "89893e69-996d-40b1-ba32-8ff5f34c0dd5"
 authors = ["stecrotti <stefano.crotti@polito.it>", "abraunst <alfredo.braunstein@polito.it"]
-version = "0.9"
+version = "0.9.0"
 
 [deps]
 Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorTrains"
 uuid = "89893e69-996d-40b1-ba32-8ff5f34c0dd5"
 authors = ["stecrotti <stefano.crotti@polito.it>", "abraunst <alfredo.braunstein@polito.it"]
-version = "0.8"
+version = "0.9"
 
 [deps]
 Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"

--- a/src/TensorTrains.jl
+++ b/src/TensorTrains.jl
@@ -16,10 +16,10 @@ using StatsBase
 export 
     SVDTrunc, TruncBond, TruncThresh, TruncBondMax, TruncBondThresh, summary_compact,
     AbstractTensorTrain, TensorTrain, normalize_eachmatrix!, +, -, ==, isapprox, evaluate, 
-    bond_dims, uniform_tt, rand_tt, orthogonalize_right!, orthogonalize_left!, compress!,
+    bond_dims, flat_tt, rand_tt, orthogonalize_right!, orthogonalize_left!, compress!,
     marginals, twovar_marginals, normalization, normalize!, dot, norm, norm2m,
     sample!, sample,
-    PeriodicTensorTrain, uniform_periodic_tt, rand_periodic_tt
+    PeriodicTensorTrain, flat_periodic_tt, rand_periodic_tt
 
 include("utils.jl")
 include("svd_trunc.jl")

--- a/src/periodic_tensor_train.jl
+++ b/src/periodic_tensor_train.jl
@@ -23,8 +23,8 @@ end
     check_bond_dims, length, eachindex
 
 """
-    uniform_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)
-    uniform_periodic_tt(d::Integer, L::Integer, q...)
+    flat_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)
+    flat_periodic_tt(d::Integer, L::Integer, q...)
 
 Construct a Tensor Train with periodic boundary conditions full of 1's, by specifying either:
 - `bondsizes`: the size of each bond
@@ -32,11 +32,11 @@ Construct a Tensor Train with periodic boundary conditions full of 1's, by speci
 and
 - `q` a Tuple/Vector specifying the number of values taken by each variable on a single site
 """
-function uniform_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)
+function flat_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)
     tensors = [ones(bondsizes[t], bondsizes[mod1(t+1,length(bondsizes))], q...) for t in eachindex(bondsizes)]
     PeriodicTensorTrain(tensors)
 end
-uniform_periodic_tt(d::Integer, L::Integer, q...) = uniform_periodic_tt(fill(d, L-1), q...)
+flat_periodic_tt(d::Integer, L::Integer, q...) = flat_periodic_tt(fill(d, L-1), q...)
 
 """
     rand_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)

--- a/src/tensor_train.jl
+++ b/src/tensor_train.jl
@@ -28,8 +28,8 @@ end
 
   
 """
-    uniform_tt(bondsizes::AbstractVector{<:Integer}, q...)
-    uniform_tt(d::Integer, L::Integer, q...)
+    flat_tt(bondsizes::AbstractVector{<:Integer}, q...)
+    flat_tt(d::Integer, L::Integer, q...)
 
 Construct a Tensor Train full of 1's, by specifying either:
 - `bondsizes`: the size of each bond
@@ -37,10 +37,10 @@ Construct a Tensor Train full of 1's, by specifying either:
 and
 - `q` a Tuple/Vector specifying the number of values taken by each variable on a single site
 """
-function uniform_tt(bondsizes::AbstractVector{<:Integer}, q...)
+function flat_tt(bondsizes::AbstractVector{<:Integer}, q...)
     TensorTrain([ones(bondsizes[t], bondsizes[t+1], q...) for t in 1:length(bondsizes)-1])
 end
-uniform_tt(d::Integer, L::Integer, q...) = uniform_tt([1; fill(d, L-1); 1], q...)
+flat_tt(d::Integer, L::Integer, q...) = flat_tt([1; fill(d, L-1); 1], q...)
 
 """
     rand_tt(bondsizes::AbstractVector{<:Integer}, q...)

--- a/test/periodic_tensor_train.jl
+++ b/test/periodic_tensor_train.jl
@@ -40,7 +40,7 @@
         L = 5
         q = (2, 4)
         d = 3
-        C = uniform_periodic_tt(d, L, q...)
+        C = flat_periodic_tt(d, L, q...)
         x = [[rand(1:q[1]), rand(1:q[2])] for _ in C]
         e1 = evaluate(C, x)
 
@@ -72,7 +72,7 @@
             for q in 1:3
                 qs = fill(q, N)
                 L = 6
-                A = uniform_periodic_tt( rand(2:7, L-1), qs... )
+                A = flat_periodic_tt( rand(2:7, L-1), qs... )
                 B = rand_periodic_tt( rand(2:7, L-1), qs... )
                 x = [rand(1:q[1],N) for _ in 1:L]
                 @test evaluate(A, x) + evaluate(B, x) ≈ evaluate(A+B, x)
@@ -98,7 +98,7 @@
         svd_trunc = TruncThresh(3e-2)
         q = 4; N = 3; L = 6
         qs = fill(q, N)
-        A = uniform_periodic_tt( rand(5:20, L-1), qs... )
+        A = flat_periodic_tt( rand(5:20, L-1), qs... )
         bd1 = bond_dims(A)
         x = [rand(MersenneTwister(1234), 1:q[1],N) for _ in 1:L]
         e1 = evaluate(A, x)
@@ -112,7 +112,7 @@
         svd_trunc = TruncThresh(3e-2)
         q = 4; N = 3; L = 6
         qs = fill(q, N)
-        A = uniform_periodic_tt( rand(5:20, L-1), qs... )
+        A = flat_periodic_tt( rand(5:20, L-1), qs... )
         bd1 = bond_dims(A)
         x = [rand(MersenneTwister(1234), 1:q[1],N) for _ in 1:L]
         e1 = evaluate(A, x)
@@ -126,7 +126,7 @@
         svd_trunc = TruncThresh(0.0)
         q = 4; N = 3; L = 6
         qs = fill(q, N)
-        A = uniform_periodic_tt(rand(5:20, L-1), qs... )
+        A = flat_periodic_tt(rand(5:20, L-1), qs... )
         x1 = sample(MersenneTwister(1234), A)[1]
         orthogonalize_left!(A; svd_trunc)
         x2 = sample(MersenneTwister(1234), A)[1]

--- a/test/tensor_train.jl
+++ b/test/tensor_train.jl
@@ -86,7 +86,7 @@ end
         L = 5
         q = (2, 4)
         d = 3
-        C = uniform_tt(d, L, q...)
+        C = flat_tt(d, L, q...)
         x = [[rand(1:q[1]), rand(1:q[2])] for _ in C]
         e1 = evaluate(C, x)
 


### PR DESCRIPTION
On main, `uniform_tt` constructs a tensor trains with all entries equal ($A^i(x_i)=const\quad\forall i \quad\forall x_i$). Since "uniform" is actually a keyword in the context of matrix product states (it indicates a MPS where all $A$'s are equal independent of $i$), i think it's better to pick another name. Especially since it is likely that we'll introduce actual uniform tensor trains in the package in the future (see #22 ).