### PR TITLE
Flat tensor train comes already normalized

### DIFF
--- a/src/periodic_tensor_train.jl
+++ b/src/periodic_tensor_train.jl
@@ -27,14 +27,15 @@ end
     flat_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)
     flat_periodic_tt(d::Integer, L::Integer, q...)
 
-Construct a Tensor Train with periodic boundary conditions full of 1's, by specifying either:
+Construct a (normalized) Tensor Train with periodic boundary conditions filled with a constant, by specifying either:
 - `bondsizes`: the size of each bond
 - `d` a fixed size for all bonds, `L` the length
 and
 - `q` a Tuple/Vector specifying the number of values taken by each variable on a single site
 """
 function flat_periodic_tt(bondsizes::AbstractVector{<:Integer}, q...)
-    tensors = [ones(bondsizes[t], bondsizes[mod1(t+1,length(bondsizes))], q...) for t in eachindex(bondsizes)]
+    x = 1 / (prod(bondsizes)^(1/length(bondsizes))*prod(q))
+    tensors = [fill(x, bondsizes[t], bondsizes[mod1(t+1,length(bondsizes))], q...) for t in eachindex(bondsizes)]
     PeriodicTensorTrain(tensors)
 end
 flat_periodic_tt(d::Integer, L::Integer, q...) = flat_periodic_tt(fill(d, L-1), q...)

--- a/src/tensor_train.jl
+++ b/src/tensor_train.jl
@@ -32,14 +32,16 @@ end
     flat_tt(bondsizes::AbstractVector{<:Integer}, q...)
     flat_tt(d::Integer, L::Integer, q...)
 
-Construct a Tensor Train full of 1's, by specifying either:
+Construct a (normalized) Tensor Train filled with a constant, by specifying either:
 - `bondsizes`: the size of each bond
 - `d` a fixed size for all bonds, `L` the length
 and
 - `q` a Tuple/Vector specifying the number of values taken by each variable on a single site
 """
 function flat_tt(bondsizes::AbstractVector{<:Integer}, q...)
-    TensorTrain([ones(bondsizes[t], bondsizes[t+1], q...) for t in 1:length(bondsizes)-1])
+    L = length(bondsizes) - 1
+    x = 1 / (prod(bondsizes)^(1/L)*prod(q))
+    TensorTrain([fill(x, bondsizes[t], bondsizes[t+1], q...) for t in 1:L])
 end
 flat_tt(d::Integer, L::Integer, q...) = flat_tt([1; fill(d, L-1); 1], q...)
 

--- a/test/periodic_tensor_train.jl
+++ b/test/periodic_tensor_train.jl
@@ -17,6 +17,14 @@
         @test evaluate(A + A, x) ≈ evaluate(B + B, x)
     end
 
+    @testset "Flat" begin
+        L = 5
+        bondsizes = rand(1:4, L)
+        q = (2,4,3)
+        C = flat_periodic_tt(bondsizes, q...)
+        @assert normalization(C) ≈ 1
+    end
+
     @testset "Random" begin
         svd_trunc = TruncBondThresh(20, 0.0)
         L = 5

--- a/test/tensor_train.jl
+++ b/test/tensor_train.jl
@@ -82,11 +82,11 @@ end
         @test e3 ≈ e1
     end
 
-    @testset "Uniform" begin
-        L = 5
+    @testset "Flat" begin
         q = (2, 4)
-        d = 3
-        C = flat_tt(d, L, q...)
+        bondsizes = [1, 3, 5, 2, 1]
+        C = flat_tt(bondsizes, q...)
+        @test normalization(C) ≈ 1
         x = [[rand(1:q[1]), rand(1:q[2])] for _ in C]
         e1 = evaluate(C, x)
 


### PR DESCRIPTION
Makes `flat_tt` and `flat_periodic_tt` return an already normalized tensor train filled with a constant, rather then a tensor train full of 1's