### PR TITLE
Add option to compress already orthogonalized tensor trains

### DIFF
--- a/src/abstract_tensor_train.jl
+++ b/src/abstract_tensor_train.jl
@@ -219,9 +219,19 @@ end
 
 Compress `A` by means of SVD decompositions + truncations
 """
-function compress!(A::AbstractTensorTrain; svd_trunc=TruncThresh(1e-6))
-    orthogonalize_right!(A, svd_trunc=TruncThresh(0.0))
-    orthogonalize_left!(A; svd_trunc)
+function compress!(A::AbstractTensorTrain; svd_trunc=TruncThresh(1e-6),
+        is_orthogonal::Symbol=:none)
+    if is_orthogonal == :none
+        orthogonalize_right!(A; svd_trunc=TruncThresh(0.0))
+        orthogonalize_left!(A; svd_trunc)
+    elseif is_orthogonal == :left
+        orthogonalize_right!(A; svd_trunc)
+    elseif is_orthogonal == :right
+        orthogonalize_left!(A; svd_trunc)
+    else
+        throw(ArgumentError("Keyword `is_orthogonal` only supports: :none, :left, :right, got :$is_orthogonal"))
+    end
+    return A
 end
 
 """

--- a/src/periodic_tensor_train.jl
+++ b/src/periodic_tensor_train.jl
@@ -78,7 +78,7 @@ end
 PeriodicTensorTrain(A::TensorTrain) = PeriodicTensorTrain(A.tensors)
 
 
-function orthogonalize_right!(C::PeriodicTensorTrain{F}; svd_trunc=TruncThresh(1e-6)) where F
+function orthogonalize_right!(C::PeriodicTensorTrain{F}; svd_trunc=TruncThresh(0.0)) where F
     C⁰ = _reshape1(C[begin])
     q = size(C⁰, 3)
     @cast M[m, (n, x)] := C⁰[m, n, x]
@@ -108,7 +108,7 @@ function orthogonalize_right!(C::PeriodicTensorTrain{F}; svd_trunc=TruncThresh(1
     return C
 end
 
-function orthogonalize_left!(A::PeriodicTensorTrain{F}; svd_trunc=TruncThresh(1e-6)) where F
+function orthogonalize_left!(A::PeriodicTensorTrain{F}; svd_trunc=TruncThresh(0.0)) where F
     A⁰ = _reshape1(A[begin])
     q = size(A⁰, 3)
     @cast M[(m, x), n] |= A⁰[m, n, x]

--- a/test/periodic_tensor_train.jl
+++ b/test/periodic_tensor_train.jl
@@ -31,6 +31,23 @@
         @test tr(l[begin] * m[1,end] * r[end]) ≈ Z
     end
 
+    @testset "Compression" begin
+        tensors = [rand(1,3,2,2), rand(3,4,2,2), rand(4,10,2,2), rand(10,1,2,2)]
+        A = PeriodicTensorTrain(tensors)
+        x, = sample(A)
+        B = deepcopy(A)
+        C = deepcopy(A)
+        svd_trunc = TruncThresh(1e-2)
+        compress!(A; svd_trunc)
+        orthogonalize_right!(B; svd_trunc = TruncThresh(0.0))
+        compress!(B; svd_trunc, is_orthogonal=:right)
+        orthogonalize_left!(C; svd_trunc = TruncThresh(0.0))
+        compress!(C; svd_trunc, is_orthogonal=:left)
+        @test evaluate(A, x) ≈ evaluate(B, x) ≈ evaluate(C, x)
+        @test_throws ArgumentError compress!(A; is_orthogonal=:something)
+    end
+
+
     @testset "Long tensor trains" begin
         rng = MersenneTwister(0)
         qs = (2, 2)

--- a/test/tensor_train.jl
+++ b/test/tensor_train.jl
@@ -119,6 +119,22 @@ end
         @test only(l[begin] * m[1,end] * r[end]) ≈ Z
     end
 
+    @testset "Compression" begin
+        tensors = [rand(1,3,2,2), rand(3,4,2,2), rand(4,10,2,2), rand(10,1,2,2)]
+        A = TensorTrain(tensors)
+        x, = sample(A)
+        B = deepcopy(A)
+        C = deepcopy(A)
+        svd_trunc = TruncThresh(1e-2)
+        compress!(A; svd_trunc)
+        orthogonalize_right!(B; svd_trunc = TruncThresh(0.0))
+        compress!(B; svd_trunc, is_orthogonal=:right)
+        orthogonalize_left!(C; svd_trunc = TruncThresh(0.0))
+        compress!(C; svd_trunc, is_orthogonal=:left)
+        @test evaluate(A, x) ≈ evaluate(B, x) ≈ evaluate(C, x)
+        @test_throws ArgumentError compress!(A; is_orthogonal=:something)
+    end
+
     @testset "Long tensor trains" begin
         rng = MersenneTwister(0)
         qs = (2, 2)


### PR DESCRIPTION
If a tensor train is already orthogonal (left or right), compression only needs one sweep in the opposite direction