### PR TITLE
better isapprox for AbstractTensorTrain

### DIFF
--- a/src/abstract_tensor_train.jl
+++ b/src/abstract_tensor_train.jl
@@ -338,7 +338,7 @@ function LinearAlgebra.dot(A::AbstractTensorTrain, B::AbstractTensorTrain)
     end
 
     @tullio d = C[a¹,a¹,b¹,b¹]
-    return d / float(A.z * B.z)
+    return d / float(A.z * conj(B.z)) # B.z should be real, but let's be safe here
 end
 
 @doc raw"""
@@ -361,7 +361,7 @@ Given two tensor trains `A,B`, compute `norm(A - B)^2` as
 \lVert A-B\rVert_2^2 = \lVert A \rVert_2^2 + \lVert B \rVert_2^2 - 2A\cdot B
 ```
 """
-function norm2m(A::AbstractTensorTrain, B::AbstractTensorTrain) 
+function norm2m(A::AbstractTensorTrain, B::AbstractTensorTrain)
     return norm(A)^2 + norm(B)^2 - 2*real(dot(A, B))
 end
 

--- a/src/abstract_tensor_train.jl
+++ b/src/abstract_tensor_train.jl
@@ -56,7 +56,6 @@ function evaluate(A::AbstractTensorTrain, X...)
 end
 
 Base.:(==)(A::T, B::T) where {T<:AbstractTensorTrain} = isequal(A.tensors, B.tensors)
-Base.isapprox(A::T, B::T; kw...) where {T<:AbstractTensorTrain} = isapprox(A.tensors, B.tensors; kw...)
 
 trace(At) = @tullio _[aᵗ,aᵗ⁺¹] := _reshape1(At)[aᵗ,aᵗ⁺¹,x]
 
@@ -364,4 +363,9 @@ Given two tensor trains `A,B`, compute `norm(A - B)^2` as
 """
 function norm2m(A::AbstractTensorTrain, B::AbstractTensorTrain) 
     return norm(A)^2 + norm(B)^2 - 2*real(dot(A, B))
+end
+
+function Base.isapprox(A::AbstractTensorTrain, B::AbstractTensorTrain; atol::Real=0, rtol::Real=1e-6)
+    na, nb = norm(A), norm(B)
+    na^2 + nb^2 - 2real(dot(A,B)) <= max(atol, rtol*max(na, nb))^2
 end

--- a/test/tensor_train.jl
+++ b/test/tensor_train.jl
@@ -246,6 +246,23 @@ rng = MersenneTwister(0)
         end
     end
 
+    @testset "Approx and sum of TTs" begin
+        for N in 1:3
+            for q in 1:3
+                qs = fill(q, N)
+                L = 6
+                A = rand_tt( [1; rand(1:7, L-1); 1], qs... )
+                B = rand_tt( [1; rand(1:7, L-1); 1], qs... )
+                @test (A + B) - B ≈ A
+
+                C = deepcopy(A)
+                C.z /= 2
+                @test C ≈ A + A
+            end
+        end
+    end
+
+
     @testset "Difference of TTs" begin
         rng = MersenneTwister(0)
         L = 4

--- a/test/tensor_train.jl
+++ b/test/tensor_train.jl
@@ -253,7 +253,7 @@ rng = MersenneTwister(0)
                 L = 6
                 A = rand_tt( [1; rand(1:7, L-1); 1], qs... )
                 B = rand_tt( [1; rand(1:7, L-1); 1], qs... )
-                @test (A + B) - B ≈ A
+                @test isapprox((A + B) - B,  A; rtol=1e-4)
 
                 C = deepcopy(A)
                 C.z /= 2


### PR DESCRIPTION
Comparing matrices doesn't make much sense in this context; apart from the fact that they could have different sizes, there's also the gauge invariance.  If needed, the old behaviour can be recovered simply with `isapprox(A.tensors, B.tensors)`