### PR TITLE
normalization for accumulate_M

### DIFF
--- a/src/abstract_tensor_train.jl
+++ b/src/abstract_tensor_train.jl
@@ -116,7 +116,7 @@ function accumulate_R(A::AbstractTensorTrain{F}; normalize=true) where {F}
     return R, z
 end
 
-function accumulate_M(A::AbstractTensorTrain{F}) where {F}
+function accumulate_M(A::AbstractTensorTrain{F}; normalize=true) where {F}
     L = length(A)
     M = fill(zeros(F, 0, 0), L, L)
 
@@ -124,6 +124,10 @@ function accumulate_M(A::AbstractTensorTrain{F}) where {F}
         Au = trace(A[u-1])
         for t in 1:u-2
             M[t, u] = M[t, u-1] * Au
+            nt = maximum(abs, M[t,u])
+            if !iszero(nt) && normalize
+                M[t,u] ./= nt
+            end
         end
         # initial condition
         M[u-1, u] = Matrix{F}(I, size(A[u],1), size(A[u],1))

--- a/test/periodic_tensor_train.jl
+++ b/test/periodic_tensor_train.jl
@@ -24,7 +24,7 @@
         A = PeriodicTensorTrain(tensors)
         l, = TensorTrains.accumulate_L(A; normalize=false)
         r, = TensorTrains.accumulate_R(A; normalize=false)
-        m = TensorTrains.accumulate_M(A)
+        m = TensorTrains.accumulate_M(A; normalize=false)
         Z = float(normalization(A))
         @test Z ≈ exact_normalization(A)
         @test TensorTrains.accumulate_R(A)[2] ≈ Z

--- a/test/tensor_train.jl
+++ b/test/tensor_train.jl
@@ -186,7 +186,7 @@ rng = MersenneTwister(0)
         A = randn_tt(3, 4, 2, 2)
         l, = TensorTrains.accumulate_L(A; normalize=false)
         r, = TensorTrains.accumulate_R(A; normalize=false)
-        m = TensorTrains.accumulate_M(A)
+        m = TensorTrains.accumulate_M(A; normalize=false)
         Z = float(normalization(A))
         @test Z ≈ exact_normalization(A)
         @test TensorTrains.accumulate_R(A)[2] ≈ Z


### PR DESCRIPTION
This should avoid numerical errors when computing two-variable marginals, for example.